### PR TITLE
Fixed bug in ProgrammingGuide

### DIFF
--- a/vignettes/ProgrammingGuide.Rmd
+++ b/vignettes/ProgrammingGuide.Rmd
@@ -56,7 +56,7 @@ w1 <- createWorld(minPxcor = 0, maxPxcor = 10, minPycor = 0, maxPycor = 10)
 
 # Report the distance between the patch [pxcor = 0, pycor = 0] and the patch [pxcor = 1, pycor = 1]
 pDist <- NLdist(agents = cbind(pxcor = 0, pycor = 0),
-                agents2 = cbind(pxcor = 1, pycor = 1, world = w1, torus = TRUE)
+                agents2 = cbind(pxcor = 1, pycor = 1), world = w1, torus = TRUE)
 ```
 
 In `NetLogoR`, the function arguments indicate which world and/or agents (*i.e.*, patches and/or turtles) are involved in the function.


### PR DESCRIPTION
The example was missing a parenthesis, corrected that.