### PR TITLE
fix [ on a worldArray with other than two layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * the `sp` package is being retired in favour of `sf`, so everything in `NetLogoR` that still depends on it is now deprecated and will be removed in a future release. This affects `spdf2turtles()` (use `sf2turtles()`), `turtles2spdf()` (use `turtles2sf()`), `bbox()` on `sp` and `raster` objects, `wrap()` on `SpatialPoints` and `SpatialPointsDataFrame` objects, and passing a `SpatialPointsDataFrame` to `agentMatrix()`. The full transition to `sf` will follow in a separate release.
 
 ## Bugfixes
+* `[` on a `worldArray` assumed the array had exactly two layers, so extracting patch values from a `worldArray` with any other number of layers failed with "dims [product 2] do not match the length of object". It now uses the actual number of layers.
 * `inRadius()` with `torus = TRUE` no longer reports patches that were not among the `agents2` supplied;
 * `of()` on an `agentMatrix` now returns columns in the order given by `var` when a mix of factor and numeric variables is requested.
 

--- a/R/worldNLR-classes-methods.R
+++ b/R/worldNLR-classes-methods.R
@@ -257,10 +257,11 @@ setMethod(
     colMat <- i - x@minPxcor + 1
     rowMat <- x@maxPycor - j + 1
     pCoords <- cbind(rowMat, colMat)
-    cellValues <- unlist(lapply(seq_len(dim(x)[3]), function(z) {
+    nLayers <- dim(x)[3]
+    cellValues <- unlist(lapply(seq_len(nLayers), function(z) {
       as.numeric(t(x@.Data[cbind(pCoords, z)]))
     }))
-    dim(cellValues) <- c(NROW(pCoords), 2L)
+    dim(cellValues) <- c(NROW(pCoords), nLayers)
     colnames(cellValues) <- dimnames(x@.Data)[[3]]
     return(cellValues)
   }

--- a/tests/testthat/test-NetLogoR-classes.R
+++ b/tests/testthat/test-NetLogoR-classes.R
@@ -109,6 +109,28 @@ test_that("[] works with worldArray", {
   expect_equivalent(ws[], cbind(c(NA, NA, NA, NA), c(NA, NA, NA, NA)))
 })
 
+test_that("[] works with a worldArray of any number of layers", {
+  w1 <- createWorld(minPxcor = 0, maxPxcor = 1, minPycor = 0, maxPycor = 1, data = c(1, 2, 3, 4))
+  w2 <- createWorld(minPxcor = 0, maxPxcor = 1, minPycor = 0, maxPycor = 1, data = c(10, 20, 30, 40))
+  w3 <- createWorld(minPxcor = 0, maxPxcor = 1, minPycor = 0, maxPycor = 1, data = c(100, 200, 300, 400))
+
+  ## a single layer, and more than the two that [ used to assume
+  ws1 <- stackWorlds(w1)
+  expect_identical(ws1[0, 0], cbind(w1 = 3))
+
+  ws3 <- stackWorlds(w1, w2, w3)
+  expect_identical(numLayers(ws3), 3L)
+  expect_identical(ws3[0, 0], cbind(w1 = 3, w2 = 30, w3 = 300))
+  expect_identical(
+    ws3[c(0, 1), 1],
+    cbind(w1 = c(1, 2), w2 = c(10, 20), w3 = c(100, 200))
+  )
+  expect_equivalent(ws3[], cbind(c(1, 2, 3, 4), c(10, 20, 30, 40), c(100, 200, 300, 400)))
+
+  ws4 <- stackWorlds(w1, w2, w3, w1)
+  expect_identical(dim(ws4[0, 0]), c(1L, 4L))
+})
+
 test_that("cellFromPxcorPycor works", {
   w3 <- createWorld(minPxcor = 0, maxPxcor = 9, minPycor = 0, maxPycor = 9)
   cellNum <- cellFromPxcorPycor(world = w3, pxcor = c(9, 0, 1), pycor = c(0, 0, 9))


### PR DESCRIPTION
Found while investigating #49; unrelated to it and worth landing on its own.

`[` on a `worldArray` hardcoded the layer count when reshaping the extracted values:

```r
dim(cellValues) <- c(NROW(pCoords), 2L)
```

so it only ever worked on a two-layer array:

```r
w1 <- createWorld(minPxcor = 0, maxPxcor = 4, minPycor = 0, maxPycor = 4, data = 1:25)
w2 <- createWorld(minPxcor = 0, maxPxcor = 4, minPycor = 0, maxPycor = 4, data = 26:50)
w3 <- createWorld(minPxcor = 0, maxPxcor = 4, minPycor = 0, maxPycor = 4, data = 51:75)

a3 <- stackWorlds(w1, w2, w3)
a3[1, 1]
#> Error: dims [product 2] do not match the length of object [3]
```

A single-layer `stackWorlds(w1)` failed the same way. Now uses `dim(x)[3]`.

The sibling `[,worldArray,missing,missing` method already computed this correctly, which is why `a3[]` worked while `a3[1, 1]` did not — only the coordinate-indexed method was affected.

I checked the rest of the `worldArray` API against a three-layer array while I was in there: `of()`, `NLset()`, `[<-`, `[[`, `numLayers()`, `layerNames()`, `plot()` and `world2spatRast()` all already handled arbitrary layer counts. This was the only site.

Tests cover one, three and four layers.

## Verification

- `R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes
- `devtools::test()`: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
