### PR TITLE
store worldArray character layers as levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 
 ## Bugfixes
 * `[` on a `worldArray` assumed the array had exactly two layers, so extracting patch values from a `worldArray` with any other number of layers failed with "dims [product 2] do not match the length of object". It now uses the actual number of layers.
+* stacking a `worldMatrix` of character values alongside a numeric one no longer corrupts both layers (#49). An `array` holds a single type, so the character values used to turn every layer into character, and were then coerced back to `NA` on the way out. `worldArray` now stores character layers as integer codes with their categories in a new `levels` slot, exactly as `agentMatrix` already does for character columns. `of()` reports the character values, `plot()` draws the layer as a categorical raster instead of warning "NAs introduced by coercion", `NLwith()` and `NLset()` accept and return the characters, and `[[` and `$` give back a character `worldMatrix`. Numeric layers stacked alongside a character one keep their own type.
 * `inRadius()` with `torus = TRUE` no longer reports patches that were not among the `agents2` supplied;
 * `of()` on an `agentMatrix` now returns columns in the order given by `var` when a mix of factor and numeric variables is requested.
 

--- a/R/agentset-functions.R
+++ b/R/agentset-functions.R
@@ -371,7 +371,12 @@ setMethod(
     colMat <- agents[, 1] - world@minPxcor + 1
     rowMat <- world@maxPycor - agents[, 2] + 1
     layerIdx <- .layerIndices(world, var)
-    agentsValues <- world@.Data[cbind(rowMat, colMat, layerIdx)]
+    ## a character layer is stored as codes, so compare `val` against the
+    ## character values the user actually supplied (#49)
+    agentsValues <- .decodeLayer(
+      world@.Data[cbind(rowMat, colMat, layerIdx)],
+      .layerLevels(world, var)
+    )
     pVal <- which(agentsValues %in% val)
     return(agents[pVal, , drop = FALSE])
   }
@@ -2109,7 +2114,9 @@ setMethod(
         }
 
         if (identical(world@pCoords, agents)) {
-          world@.Data[, , var] <- matrix(val, ncol = dim(world)[2], byrow = TRUE)
+          enc <- .encodeForLayer(world, var, val, allPatches = TRUE)
+          world <- enc$world
+          world@.Data[, , var] <- matrix(enc$val, ncol = dim(world)[2], byrow = TRUE)
         } else {
           agents[is.na(agents[, 1]), 2] <- NA
           agents[is.na(agents[, 2]), 1] <- NA
@@ -2121,8 +2128,11 @@ setMethod(
           matj <- pxcor - world@minPxcor + 1
           mati <- world@maxPycor - pycor + 1
 
+          enc <- .encodeForLayer(world, var, val)
+          world <- enc$world
+
           vark <- match(var, dimnames(world@.Data)[[3]])
-          world@.Data[cbind(mati, matj, vark)] <- val
+          world@.Data[cbind(mati, matj, vark)] <- enc$val
         }
       } else {
         if (identical(world@pCoords, agents)) {
@@ -2132,7 +2142,9 @@ setMethod(
             if (length(vali) == 1) {
               vali <- rep(vali, NROW(agents))
             }
-            world@.Data[, , var[i]] <- matrix(vali, ncol = dim(world)[2], byrow = TRUE)
+            enc <- .encodeForLayer(world, var[i], vali, allPatches = TRUE)
+            world <- enc$world
+            world@.Data[, , var[i]] <- matrix(enc$val, ncol = dim(world)[2], byrow = TRUE)
           }
         } else {
           matj <- agents[, 1] - world@minPxcor + 1
@@ -2155,8 +2167,10 @@ setMethod(
           mati <- mati[!is.na(mati)]
 
           for (i in seq_along(var)) {
+            enc <- .encodeForLayer(world, var[i], val[, var[i]])
+            world <- enc$world
             vark <- match(var[i], dimnames(world@.Data)[[3]])
-            world@.Data[cbind(mati, matj, vark)] <- val[, var[i]]
+            world@.Data[cbind(mati, matj, vark)] <- enc$val
           }
         }
       }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -10,6 +10,98 @@ sampleWithin <- function(group) {
 
 .coordsColNames <- c("xcor", "ycor")
 
+## A worldArray holds a single R array, so a character layer stacked alongside a
+## numeric one would coerce the whole array to character. Character layers are
+## therefore stored as integer codes with their levels kept in the @levels slot,
+## exactly as agentMatrix does for its character columns.
+##
+## Note the test is is.character()/is.factor() rather than !is.numeric(): a world
+## created with the default data = NA has a *logical* matrix, which must be left
+## alone rather than encoded as a one-level factor.
+.encodeLayer <- function(mat) {
+  if (!(is.character(mat) || is.factor(mat))) {
+    return(list(data = mat, levels = NULL))
+  }
+  fac <- factor(as.vector(mat))
+  codes <- matrix(as.integer(fac), nrow = nrow(mat), ncol = ncol(mat))
+  list(data = codes, levels = levels(fac))
+}
+
+## Map integer codes back to their character values. `levels = NULL` marks a
+## numeric layer, which is returned untouched.
+.decodeLayer <- function(values, levels) {
+  if (is.null(levels)) {
+    return(values)
+  }
+  decoded <- levels[values]
+  if (!is.null(dim(values))) {
+    dim(decoded) <- dim(values)
+    dimnames(decoded) <- dimnames(values)
+  }
+  decoded
+}
+
+## Levels for `var`, or NULL when that layer is numeric. Works for any worldNLR;
+## a worldMatrix has no @levels slot because its matrix can hold characters
+## directly.
+.layerLevels <- function(world, var) {
+  if (!.hasSlot(world, "levels")) {
+    return(NULL)
+  }
+  world@levels[[var]]
+}
+
+.hasSlot <- function(object, name) {
+  name %in% methods::slotNames(class(object))
+}
+
+## TRUE if any of `var` is stored as codes.
+.anyCoded <- function(world, var) {
+  any(vapply(var, function(v) !is.null(.layerLevels(world, v)), logical(1)))
+}
+
+## Prepare `val` for assignment into worldArray layer `var`, returning the world
+## with any newly seen character values appended to that layer's levels, and the
+## integer codes to write. `union()` keeps the existing levels in place, so codes
+## already stored in unassigned patches stay valid.
+##
+## Turning a numeric layer into a character one is only meaningful when every
+## patch is assigned; otherwise the numbers still sitting in the layer would
+## silently be reinterpreted as codes, so that case is rejected.
+.encodeForLayer <- function(world, var, val, allPatches = FALSE) {
+  lvls <- world@levels[[var]]
+  valIsChar <- is.character(val) || is.factor(val)
+
+  if (is.null(lvls)) {
+    if (!valIsChar) {
+      return(list(world = world, val = val))
+    }
+
+    ## `cbind(num = 1, hab = "ice")` is a character matrix, so numbers reach a
+    ## numeric layer as strings. Put them back when they convert cleanly, rather
+    ## than treating genuinely numeric data as new categories. Pass `val` as a
+    ## data.frame to keep the column types distinct in the first place.
+    asNum <- suppressWarnings(as.numeric(as.character(val)))
+    if (!any(is.na(asNum) & !is.na(val))) {
+      return(list(world = world, val = asNum))
+    }
+
+    if (!allPatches) {
+      stop(
+        "cannot assign character values to only some patches of the numeric ",
+        "worldArray layer '", var, "'.\n",
+        "Assign the whole layer instead, e.g. world[['", var, "']] <- aCharacterWorld."
+      )
+    }
+    lvls <- character(0)
+  }
+
+  newLvls <- union(lvls, setdiff(unique(as.character(val)), NA_character_))
+  world@levels[[var]] <- newLvls
+
+  list(world = world, val = match(as.character(val), newLvls))
+}
+
 ## Deprecation notice for the parts of the package that still rely on sp, which
 ## is being retired in favour of sf. `what` names the deprecated function or
 ## code path; `instead` spells out the sf-based way to do the same thing, so

--- a/R/turtle-functions.R
+++ b/R/turtle-functions.R
@@ -3164,29 +3164,42 @@ setMethod(
   "of",
   signature = c("worldArray", "matrix", "character"),
   definition = function(world, agents, var) {
+    layerIdx <- .layerIndices(world, var)
     nCell <- (world@maxPxcor - world@minPxcor + 1) * (world@maxPycor - world@minPycor + 1)
-    if (nrow(agents) == nCell && identical(world@pCoords, agents)) {
-      allValues <- world[]
-      return(allValues[, var])
-    } else {
 
+    if (nrow(agents) == nCell && identical(world@pCoords, agents)) {
+      cellValues <- world[][, var, drop = FALSE]
+    } else {
       colMat <- agents[, 1] - world@minPxcor + 1
       rowMat <- world@maxPycor - agents[, 2] + 1
-      layerIdx <- .layerIndices(world, var)
 
-      if (length(var) == 1) {
-        return(world@.Data[cbind(rowMat, colMat, layerIdx)])
-      } else {
-
-        cellValues <- vapply(layerIdx, function(z) {
-          world@.Data[cbind(rowMat, colMat, z)]
-        }, FUN.VALUE = numeric(length(rowMat)))
-        cellValues <- matrix(cellValues, nrow = length(rowMat), ncol = length(var))
-        colnames(cellValues) <- var
-
-        return(cellValues)
-      }
+      cellValues <- vapply(layerIdx, function(z) {
+        world@.Data[cbind(rowMat, colMat, z)]
+      }, FUN.VALUE = numeric(length(rowMat)))
+      cellValues <- matrix(cellValues, nrow = length(rowMat), ncol = length(var))
+      colnames(cellValues) <- var
     }
+
+    ## character layers are held as integer codes, so report their values (#49).
+    ## With a mix of coded and numeric layers the result cannot be a matrix, so
+    ## return a data.frame, as `of` on an agentMatrix does for its factors.
+    ## unname(): subsetting a single column out of a one-row matrix carries the
+    ## column name across, where indexing the array directly never did
+    if (!.anyCoded(world, var)) {
+      if (length(var) == 1) {
+        return(unname(cellValues[, 1]))
+      }
+      return(cellValues)
+    }
+
+    cols <- lapply(var, function(v) {
+      unname(.decodeLayer(cellValues[, v], .layerLevels(world, v)))
+    })
+    if (length(var) == 1) {
+      return(cols[[1]])
+    }
+    names(cols) <- var
+    return(list2DF(cols))
   }
 )
 

--- a/R/world-functions.R
+++ b/R/world-functions.R
@@ -610,11 +610,16 @@ setMethod(
   signature = c("worldArray"),
   definition = function(world) {
     exts <- extents(world@extent)
+    layerNames <- dimnames(world@.Data)[[3]]
     listRaster <- lapply(seq_len(dim(world)[3]), function(x) {
+      ## hand terra the character values of a coded layer rather than its
+      ## integer codes: terra turns those into a categorical layer by itself,
+      ## which is what a standalone character worldMatrix already produces (#49)
+      vals <- .decodeLayer(world@.Data[, , x], world@levels[[layerNames[x]]])
       ras <- terra::rast(
         xmin = exts$xmin, xmax = exts$xmax,
         ymin = exts$ymin, ymax = exts$ymax,
-        ncols = ncol(world), nrows = nrow(world), vals = world@.Data[, , x]
+        ncols = ncol(world), nrows = nrow(world), vals = vals
       )
     })
     rasterStack <- rast(listRaster)
@@ -650,6 +655,15 @@ setMethod(
     maxv <- format(apply(object@.Data, 3, max))
     minv <- gsub("Inf", "?", minv)
     maxv <- gsub("-Inf", "?", maxv)
+
+    ## a character layer is stored as codes, so report its first and last
+    ## category rather than the meaningless smallest and largest code (#49)
+    coded <- match(names(object@levels), dimnames(object@.Data)[[3]])
+    if (length(coded)) {
+      minv[coded] <- vapply(object@levels, function(l) l[[1L]], character(1))
+      maxv[coded] <- vapply(object@levels, function(l) l[[length(l)]], character(1))
+    }
+
     nl <- numLayers(object)
     mnr <- 15
 

--- a/R/worldNLR-classes-methods.R
+++ b/R/worldNLR-classes-methods.R
@@ -219,6 +219,17 @@ setMethod(
 #' (i.e., same values for all their slots) stacked together.
 #' It is used to keep more than one value per `patch`.
 #'
+#' An `array` can hold only one type of value, so a `worldMatrix` of character
+#' values stacked alongside a numeric one would coerce every layer to character.
+#' Character layers are therefore stored as integer codes, and the `levels` slot
+#' holds a named list mapping those codes back to their character values, in the
+#' same way that [agentMatrix()] stores its character columns. Layers that are
+#' numeric have no entry in `levels`.
+#'
+#' Accessors return the character values rather than the codes: [of()] on a
+#' character layer reports the characters, and `[[` and `$` return a character
+#' `worldMatrix`. The codes are visible only in the `.Data` slot itself.
+#'
 #' @aliases worldArray
 #' @name worldArray-class
 #' @rdname worldArray-class
@@ -236,12 +247,18 @@ setClass(
     maxPycor = "numeric",
     extent = "ANY",
     res = "numeric",
-    pCoords = "matrix"
+    pCoords = "matrix",
+    levels = "list"
   ),
+  prototype = prototype(levels = list()),
   validity = function(object) {
     # check for valid extents
     if (any(!inherits(object@extent, c("Extent", "SpatExtent")))) {
       stop("must supply an object name")
+    }
+    if (length(object@levels) &&
+      !all(names(object@levels) %in% dimnames(object@.Data)[[3]])) {
+      stop("names of 'levels' must all be layers of the worldArray")
     }
   }
 )
@@ -372,11 +389,19 @@ setMethod(
     a <- lapply(NLwMs, FUN = function(x) x@extent)
 
     # Vectorized all.equal
-    if (isTRUE(all(ae(a[-1], a[1]) %in% TRUE))) {
-      out <- simplify2array(NLwMs) # abind::abind(NLwMs@.Data, along = 3)
-    } else {
+    if (!isTRUE(all(ae(a[-1], a[1]) %in% TRUE))) {
       stop("worldMatrix extents must all be equal")
     }
+
+    ## An array holds a single type, so character layers are stored as integer
+    ## codes and their levels kept alongside; otherwise stacking a character
+    ## world with a numeric one would turn every layer into character (#49).
+    encoded <- lapply(NLwMs, function(x) .encodeLayer(x@.Data))
+    lvls <- lapply(encoded, `[[`, "levels")
+    names(lvls) <- objNames
+    lvls <- lvls[!vapply(lvls, is.null, logical(1))]
+
+    out <- simplify2array(lapply(encoded, `[[`, "data"))
     dimnames(out) <- list(NULL, NULL, objNames)
 
     world <- new("worldArray",
@@ -385,7 +410,8 @@ setMethod(
       minPycor = NLwMs[[1]]@minPycor, maxPycor = NLwMs[[1]]@maxPycor,
       extent = NLwMs[[1]]@extent,
       res = c(1, 1),
-      pCoords = NLwMs[[1]]@pCoords
+      pCoords = NLwMs[[1]]@pCoords,
+      levels = lvls
     )
 
     return(world)
@@ -578,16 +604,21 @@ setMethod(
 #'
 setMethod("[[", signature(x = "worldArray", i = "ANY", j = "missing"),
   definition = function(x, i) {
+    layerNames <- if (is.character(i)) i else dimnames(x@.Data)[[3]][i]
+
     if (length(i) > 1) {
+      x@levels <- x@levels[names(x@levels) %in% layerNames]
       x@.Data <- x@.Data[, , i]
       return(x)
     } else {
       worldMat <- .emptyWorldMatrix()
       sns <- .slotNames(x)
-      for (sn in sns[sns != ".Data"]) {
+      for (sn in sns[!sns %in% c(".Data", "levels")]) {
         slot(worldMat, sn, check = FALSE) <- slot(x, sn)
       }
-      worldMat@.Data <- x@.Data[, , i]
+      ## a single layer becomes a worldMatrix, whose matrix can hold the
+      ## character values directly, so decode on the way out (#49)
+      worldMat@.Data <- .decodeLayer(x@.Data[, , i], x@levels[[layerNames]])
       return(worldMat)
     }
   }
@@ -604,7 +635,14 @@ setMethod("[[", signature(x = "worldArray", i = "ANY", j = "missing"),
 #' @rdname subsetting
 setReplaceMethod("[[", signature(x = "worldArray", i = "ANY", j = "missing"),
   definition = function(x, i, value) {
-    x@.Data[, , i] <- value
+    layerName <- if (is.character(i)) i else dimnames(x@.Data)[[3]][i]
+
+    ## re-encode, so that dropping a character layer in keeps the array numeric
+    ## and swapping a numeric one back in clears the stale levels (#49)
+    encoded <- .encodeLayer(if (is(value, "worldMatrix")) value@.Data else value)
+    x@.Data[, , i] <- encoded$data
+    x@levels[[layerName]] <- encoded$levels
+
     return(x)
   }
 )

--- a/man/worldArray-class.Rd
+++ b/man/worldArray-class.Rd
@@ -11,6 +11,18 @@ It is a collection of several \code{worldMatrix} objects with the same extent
 (i.e., same values for all their slots) stacked together.
 It is used to keep more than one value per \code{patch}.
 }
+\details{
+An \code{array} can hold only one type of value, so a \code{worldMatrix} of character
+values stacked alongside a numeric one would coerce every layer to character.
+Character layers are therefore stored as integer codes, and the \code{levels} slot
+holds a named list mapping those codes back to their character values, in the
+same way that \code{\link[=agentMatrix]{agentMatrix()}} stores its character columns. Layers that are
+numeric have no entry in \code{levels}.
+
+Accessors return the character values rather than the codes: \code{\link[=of]{of()}} on a
+character layer reports the characters, and \code{[[} and \code{$} return a character
+\code{worldMatrix}. The codes are visible only in the \code{.Data} slot itself.
+}
 \seealso{
 \code{\link[=worldMatrix]{worldMatrix()}}
 }

--- a/tests/testthat/test-NetLogoR-classes.R
+++ b/tests/testthat/test-NetLogoR-classes.R
@@ -131,6 +131,89 @@ test_that("[] works with a worldArray of any number of layers", {
   expect_identical(dim(ws4[0, 0]), c(1L, 4L))
 })
 
+test_that("a worldArray keeps character layers as levels", {
+  num <- createWorld(0, 4, 0, 4, data = 1:25)
+  hab <- createWorld(0, 4, 0, 4, data = rep(c("sea", "land", "sea", "land", "sea"), 5))
+  w <- stackWorlds(num, hab)
+
+  ## the array stays numeric, so the numeric layer is not stringified (#49)
+  expect_false(is.character(w@.Data))
+  expect_identical(names(w@levels), "hab")
+  expect_identical(w@levels$hab, c("land", "sea"))
+
+  ## of() reports characters for the coded layer and numbers for the other
+  expect_identical(of(world = w, agents = cbind(pxcor = 1, pycor = 1), var = "hab"), "land")
+  expect_identical(of(world = w, agents = cbind(pxcor = 1, pycor = 1), var = "num"), 17)
+
+  ## a mix of the two cannot be a matrix, so it comes back as a data.frame
+  both <- of(world = w, agents = cbind(pxcor = 1, pycor = 1), var = c("num", "hab"))
+  expect_s3_class(both, "data.frame")
+  expect_identical(both$num, 17)
+  expect_identical(both$hab, "land")
+
+  ## a single layer round-trips back to a character worldMatrix
+  expect_identical(w[["hab"]]@.Data, hab@.Data)
+  expect_identical(w$hab@.Data, hab@.Data)
+  expect_identical(w[["num"]]@.Data, num@.Data)
+
+  ## an all-numeric worldArray is untouched by any of this
+  wn <- stackWorlds(num, createWorld(0, 4, 0, 4, data = 25:1))
+  expect_length(wn@levels, 0)
+  expect_true(is.matrix(of(world = wn, agents = cbind(pxcor = 1, pycor = 1),
+                           var = c("num", "createWorld(0, 4, 0, 4, data = 25:1)"))))
+})
+
+test_that("NLwith and NLset work on a character worldArray layer", {
+  num <- createWorld(0, 4, 0, 4, data = 1:25)
+  hab <- createWorld(0, 4, 0, 4, data = rep(c("sea", "land", "sea", "land", "sea"), 5))
+  w <- stackWorlds(num, hab)
+
+  land <- NLwith(agents = patches(w), world = w, var = "hab", val = "land")
+  expect_identical(NROW(land), 10L)
+  expect_identical(unique(of(world = w, agents = land, var = "hab")), "land")
+  expect_identical(NROW(NLwith(agents = patches(w), world = w, var = "hab", val = "nope")), 0L)
+
+  ## assigning an existing category, and one the layer has not seen before
+  w2 <- NLset(world = w, agents = cbind(pxcor = 0, pycor = 0), var = "hab", val = "land")
+  expect_identical(of(world = w2, agents = cbind(pxcor = 0, pycor = 0), var = "hab"), "land")
+
+  w3 <- NLset(world = w, agents = cbind(pxcor = 0, pycor = 0), var = "hab", val = "ice")
+  expect_identical(of(world = w3, agents = cbind(pxcor = 0, pycor = 0), var = "hab"), "ice")
+  expect_identical(w3@levels$hab, c("land", "sea", "ice"))
+  expect_false(is.character(w3@.Data))
+  ## the patches that were not assigned keep their original values
+  expect_identical(of(world = w3, agents = cbind(pxcor = 1, pycor = 0), var = "hab"), "land")
+
+  ## the numeric layer is unaffected
+  w4 <- NLset(world = w, agents = cbind(pxcor = 0, pycor = 0), var = "num", val = -99)
+  expect_identical(of(world = w4, agents = cbind(pxcor = 0, pycor = 0), var = "num"), -99)
+
+  ## turning only some patches of a numeric layer into characters is rejected
+  expect_error(
+    NLset(world = w, agents = cbind(pxcor = 0, pycor = 0), var = "num", val = "oops"),
+    "only some patches"
+  )
+})
+
+test_that("[[<- re-encodes a replaced worldArray layer", {
+  num <- createWorld(0, 4, 0, 4, data = 1:25)
+  hab <- createWorld(0, 4, 0, 4, data = rep("sea", 25))
+  w <- stackWorlds(num, hab)
+
+  ## swapping a numeric layer in clears the stale levels
+  w2 <- w
+  w2[["hab"]] <- num
+  expect_length(w2@levels$hab, 0)
+  expect_identical(of(world = w2, agents = cbind(pxcor = 1, pycor = 1), var = "hab"), 17)
+
+  ## and swapping a character layer in records new ones
+  w3 <- w
+  w3[["num"]] <- hab
+  expect_identical(w3@levels$num, "sea")
+  expect_identical(of(world = w3, agents = cbind(pxcor = 1, pycor = 1), var = "num"), "sea")
+  expect_false(is.character(w3@.Data))
+})
+
 test_that("cellFromPxcorPycor works", {
   w3 <- createWorld(minPxcor = 0, maxPxcor = 9, minPycor = 0, maxPycor = 9)
   cellNum <- cellFromPxcorPycor(world = w3, pxcor = c(9, 0, 1), pycor = c(0, 0, 9))


### PR DESCRIPTION
Closes #49.

## The problem

An `array` holds a single type. Stacking a character `worldMatrix` next to a numeric one therefore turned *every* layer into character, and the character values were then coerced back to `NA` on the way out:

```r
w1 <- createWorld(minPxcor = 0, maxPxcor = 4, minPycor = 0, maxPycor = 4, data = 1:25)
w2 <- createWorld(minPxcor = 0, maxPxcor = 4, minPycor = 0, maxPycor = 4, data = rep("sea", 25))
w3 <- stackWorlds(w1, w2)

of(world = w3, agents = cbind(pxcor = 1, pycor = 1), var = "w2")
#> NA
#> Warning: NAs introduced by coercion

plot(w3)
#> Warning: NAs introduced by coercion
```

The numeric layer was collateral damage too — `of(w3, var = "w1")` returned the string `"17"` rather than `17`.

## The fix

`worldArray` gains a `levels` slot. Character layers are stored as integer codes with their categories recorded there, exactly as `agentMatrix` already does for its character columns, so the array itself stays numeric.

Accessors report the characters, never the codes:

| | before | after |
|---|---|---|
| `of(w3, var = "w2")` | `NA` + warning | `"sea"` |
| `of(w3, var = "w1")` | `"17"` (character) | `17` (numeric) |
| `of(w3, var = c("w1","w2"))` | coerced matrix | `data.frame` |
| `plot(w3)` | warns, layer all `NA` | categorical layer |
| `w3[["w2"]]` | numeric `worldMatrix` | character `worldMatrix` |

`NLwith()` compares against the characters, `NLset()` encodes them and extends the levels when it meets a new category, and `[[<-` re-encodes so swapping layers cannot leave the array and the levels inconsistent. `world2spatRast()` hands terra the characters and lets terra build the categorical layer — which is exactly what a standalone character `worldMatrix` has always produced, so the two paths now agree.

An all-numeric `worldArray` is untouched by any of this: empty `levels`, matrix returns, same types.

## One deliberate restriction

Turning *some* patches of a numeric layer into characters is rejected:

```r
NLset(world = w, agents = cbind(pxcor = 0, pycor = 0), var = "num", val = "oops")
#> Error: cannot assign character values to only some patches of the numeric worldArray layer 'num'.
#> Assign the whole layer instead, e.g. world[['num']] <- aCharacterWorld.
```

The numbers left in the unassigned patches would silently be reinterpreted as codes. Assigning the whole layer is allowed, as is `world[["num"]] <- aCharacterWorld`.

Note that `cbind(num = 1, hab = "ice")` is already a character matrix before `NLset()` ever sees it, so numbers arrive at a numeric layer as strings. Those are converted back when they parse cleanly, rather than being treated as new categories. Pass a `data.frame` to keep the column types distinct.

## Rebased onto #57 and #58

Both prerequisites are merged, and this branch has been rebased onto them. Conflicts resolved:

- `R/world-functions.R` — kept #57's `ncols=`/`nrows=` fix *and* this PR's decoded `vals`, in the same `terra::rast()` call.
- `NEWS.md` and `tests/testthat/test-NetLogoR-classes.R` — both PRs' entries and test blocks retained.

With #57 in the base, `plot(w3)` is now completely silent: its `nrow`/`ncol` partial-match warnings are gone and the `NAs introduced by coercion` warning this PR removes is gone, so the two fixes compose as intended.

## Verification

- `R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes
- `devtools::test()`: 0 failures, 1225 passing (rebased onto #57, which replaced the quickPlot plotting tests)
- The reproducer from #49 verified directly: `of()` returns `"sea"`, and `plot(w3)` emits no warnings at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
